### PR TITLE
Move hardcoded secrets from ConfigMaps and Helm values to Kubernetes …

### DIFF
--- a/business_intelligence/superset.tf
+++ b/business_intelligence/superset.tf
@@ -24,6 +24,23 @@ resource "kubernetes_secret_v1" "secret_superset_secret_key" {
   ]
 }
 
+resource "kubernetes_secret_v1" "superset_oauth_credentials" {
+  metadata {
+    name      = "superset-oauth-credentials"
+    namespace = var.kubernetes_bi_namespace
+  }
+
+  data = {
+    SUPERSET_SECRET_KEY     = random_password.superset_secret_key.result
+    OAUTH_CLIENT_SECRET     = var.superset_oauth_client_secret
+    SUPERSET_ADMIN_PASSWORD = random_password.superset_admin_password.result
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.bi_namespace
+  ]
+}
+
 resource "helm_release" "superset" {
   namespace  = var.kubernetes_bi_namespace
   name       = "superset"
@@ -33,21 +50,21 @@ resource "helm_release" "superset" {
 
   values = [
     templatefile("${path.module}/templates/superset_values.tftpl", {
-      superset_secret_key         = random_password.superset_secret_key.result
-      superset_node_replica_num   = var.superset_node_replica_num
-      superset_worker_replica_num = var.superset_worker_replica_num
-      oauth_client_id             = var.superset_oauth_client_id
-      oauth_client_secret         = var.superset_oauth_client_secret
-      keycloak_auth_url           = var.keycloak_auth_url
-      keycloak_token_url          = var.keycloak_token_url
-      keycloak_issuer_url         = var.keycloak_issuer_url
-      keycloak_jwks_url           = var.keycloak_jwks_url
-      keycloak_api_base_url       = var.keycloak_api_base_url
-      superset_admin_password     = random_password.superset_admin_password.result
+      superset_node_replica_num     = var.superset_node_replica_num
+      superset_worker_replica_num   = var.superset_worker_replica_num
+      oauth_client_id               = var.superset_oauth_client_id
+      keycloak_auth_url             = var.keycloak_auth_url
+      keycloak_token_url            = var.keycloak_token_url
+      keycloak_issuer_url           = var.keycloak_issuer_url
+      keycloak_jwks_url             = var.keycloak_jwks_url
+      keycloak_api_base_url         = var.keycloak_api_base_url
+      oauth_credentials_secret_name = kubernetes_secret_v1.superset_oauth_credentials.metadata[0].name
+      superset_admin_password       = random_password.superset_admin_password.result
     })
   ]
 
   depends_on = [
-    kubernetes_namespace_v1.bi_namespace
+    kubernetes_namespace_v1.bi_namespace,
+    kubernetes_secret_v1.superset_oauth_credentials
   ]
 }

--- a/business_intelligence/templates/superset_values.tftpl
+++ b/business_intelligence/templates/superset_values.tftpl
@@ -1,6 +1,7 @@
 configOverrides:
   secret: |
-    SECRET_KEY = '${superset_secret_key}'
+    import os
+    SECRET_KEY = os.environ.get('SUPERSET_SECRET_KEY')
   enable_oauth: |
     from flask_appbuilder.security.manager import AUTH_OAUTH
     AUTH_TYPE = AUTH_OAUTH
@@ -15,7 +16,7 @@ configOverrides:
             'token_key': 'access_token',
             'remote_app': {
                 'client_id': '${oauth_client_id}',
-                'client_secret': '${oauth_client_secret}',
+                'client_secret': os.environ.get('OAUTH_CLIENT_SECRET'),
                 'client_kwargs': {
                     'scope': 'openid profile email groups',
                 },
@@ -79,6 +80,9 @@ configOverrides:
     # Allow users to self-register
     AUTH_USER_REGISTRATION = True
     AUTH_USER_REGISTRATION_ROLE = 'Gamma'
+
+envFromSecrets:
+  - ${oauth_credentials_secret_name}
 
 supersetNode:
   replicaCount: ${superset_node_replica_num}

--- a/catalog/nessie.tf
+++ b/catalog/nessie.tf
@@ -23,7 +23,8 @@ resource "kubernetes_secret_v1" "nessie_postgres_password" {
   }
 
   data = {
-    "password" = var.catalog_postgres_password
+    "password"          = var.catalog_postgres_password
+    "postgres-password" = var.catalog_postgres_password
   }
 
   depends_on = [
@@ -58,8 +59,16 @@ resource "helm_release" "nessie_postgres" {
 
   set = [
     {
-      name  = "auth.password"
-      value = var.catalog_postgres_password
+      name  = "auth.existingSecret"
+      value = kubernetes_secret_v1.nessie_postgres_password.metadata[0].name
+    },
+    {
+      name  = "auth.secretKeys.userPasswordKey"
+      value = "password"
+    },
+    {
+      name  = "auth.secretKeys.adminPasswordKey"
+      value = "postgres-password"
     },
     {
       name  = "auth.database"

--- a/identity/realm.tf
+++ b/identity/realm.tf
@@ -1,5 +1,6 @@
-# ConfigMap containing the Agartha realm configuration for Keycloak import
-resource "kubernetes_config_map_v1" "keycloak_realm" {
+# Secret containing the Agartha realm configuration for Keycloak import
+# Uses a Secret instead of ConfigMap because the realm JSON contains OAuth client secrets
+resource "kubernetes_secret_v1" "keycloak_realm" {
   metadata {
     name      = "keycloak-realm-config"
     namespace = local.namespace

--- a/main.tf
+++ b/main.tf
@@ -203,7 +203,7 @@ module "business_intelligence" {
   keycloak_auth_url            = module.agartha_identity.keycloak_auth_url
   keycloak_token_url           = module.agartha_identity.keycloak_token_url
   keycloak_issuer_url          = module.agartha_identity.keycloak_issuer_url
-  keycloak_jwks_url           = module.agartha_identity.keycloak_jwks_url
+  keycloak_jwks_url            = module.agartha_identity.keycloak_jwks_url
   keycloak_api_base_url        = module.agartha_identity.keycloak_api_base_url
 
   # Network policy - allow ingress from monitoring only

--- a/monitoring/oauth2_proxy.tf
+++ b/monitoring/oauth2_proxy.tf
@@ -8,15 +8,16 @@ resource "helm_release" "prometheus_oauth2_proxy" {
 
   values = [
     templatefile("${path.module}/templates/prometheus_oauth2_proxy_values.tftpl", {
-      client_id         = var.prometheus_oauth_client_id
-      client_secret     = var.prometheus_oauth_client_secret
-      cookie_secret     = var.prometheus_oauth_cookie_secret
+      existing_secret   = kubernetes_secret_v1.prometheus_oauth2_proxy_secret.metadata[0].name
       oidc_issuer_url   = var.keycloak_issuer_url
       ingress_base_host = var.kubernetes_ingress_base_host
     })
   ]
 
-  depends_on = [helm_release.kube_prometheus_stack]
+  depends_on = [
+    helm_release.kube_prometheus_stack,
+    kubernetes_secret_v1.prometheus_oauth2_proxy_secret
+  ]
 }
 
 # OAuth2-Proxy for Alertmanager authentication via Keycloak
@@ -29,13 +30,14 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
 
   values = [
     templatefile("${path.module}/templates/alertmanager_oauth2_proxy_values.tftpl", {
-      client_id         = var.alertmanager_oauth_client_id
-      client_secret     = var.alertmanager_oauth_client_secret
-      cookie_secret     = var.alertmanager_oauth_cookie_secret
+      existing_secret   = kubernetes_secret_v1.alertmanager_oauth2_proxy_secret.metadata[0].name
       oidc_issuer_url   = var.keycloak_issuer_url
       ingress_base_host = var.kubernetes_ingress_base_host
     })
   ]
 
-  depends_on = [helm_release.kube_prometheus_stack]
+  depends_on = [
+    helm_release.kube_prometheus_stack,
+    kubernetes_secret_v1.alertmanager_oauth2_proxy_secret
+  ]
 }

--- a/monitoring/prometheus.tf
+++ b/monitoring/prometheus.tf
@@ -8,25 +8,26 @@ resource "helm_release" "kube_prometheus_stack" {
 
   values = [
     templatefile("${path.module}/templates/prometheus_values.tftpl", {
-      grafana_admin_password      = var.grafana_admin_password
-      prometheus_retention_days   = var.prometheus_retention_days
-      prometheus_storage_size_gb  = var.prometheus_storage_size_gb
-      grafana_storage_size_gb     = var.grafana_storage_size_gb
-      minio_namespace             = var.minio_namespace
-      nessie_namespace            = var.nessie_namespace
-      trino_namespace             = var.trino_namespace
-      spark_namespace             = var.spark_namespace
-      flink_namespace             = var.flink_namespace
-      grafana_oauth_client_id     = var.grafana_oauth_client_id
-      grafana_oauth_client_secret = var.grafana_oauth_client_secret
-      keycloak_auth_url           = var.keycloak_auth_url
-      keycloak_token_url          = var.keycloak_token_url
-      keycloak_userinfo_url       = var.keycloak_userinfo_url
-      ingress_base_host           = var.kubernetes_ingress_base_host
+      grafana_admin_existing_secret = kubernetes_secret_v1.grafana_admin_credentials.metadata[0].name
+      prometheus_retention_days     = var.prometheus_retention_days
+      prometheus_storage_size_gb    = var.prometheus_storage_size_gb
+      grafana_storage_size_gb       = var.grafana_storage_size_gb
+      minio_namespace               = var.minio_namespace
+      nessie_namespace              = var.nessie_namespace
+      trino_namespace               = var.trino_namespace
+      spark_namespace               = var.spark_namespace
+      flink_namespace               = var.flink_namespace
+      grafana_oauth_client_id       = var.grafana_oauth_client_id
+      grafana_oauth_client_secret   = var.grafana_oauth_client_secret
+      keycloak_auth_url             = var.keycloak_auth_url
+      keycloak_token_url            = var.keycloak_token_url
+      keycloak_userinfo_url         = var.keycloak_userinfo_url
+      ingress_base_host             = var.kubernetes_ingress_base_host
     })
   ]
 
   depends_on = [
-    kubernetes_namespace_v1.monitoring_namespace
+    kubernetes_namespace_v1.monitoring_namespace,
+    kubernetes_secret_v1.grafana_admin_credentials
   ]
 }

--- a/monitoring/secret.tf
+++ b/monitoring/secret.tf
@@ -1,0 +1,49 @@
+resource "kubernetes_secret_v1" "grafana_admin_credentials" {
+  metadata {
+    name      = "grafana-admin-credentials"
+    namespace = var.kubernetes_monitoring_namespace
+  }
+
+  data = {
+    admin-user     = "admin"
+    admin-password = var.grafana_admin_password
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.monitoring_namespace
+  ]
+}
+
+resource "kubernetes_secret_v1" "prometheus_oauth2_proxy_secret" {
+  metadata {
+    name      = "prometheus-oauth2-proxy-secret"
+    namespace = var.kubernetes_monitoring_namespace
+  }
+
+  data = {
+    client-id     = var.prometheus_oauth_client_id
+    client-secret = var.prometheus_oauth_client_secret
+    cookie-secret = var.prometheus_oauth_cookie_secret
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.monitoring_namespace
+  ]
+}
+
+resource "kubernetes_secret_v1" "alertmanager_oauth2_proxy_secret" {
+  metadata {
+    name      = "alertmanager-oauth2-proxy-secret"
+    namespace = var.kubernetes_monitoring_namespace
+  }
+
+  data = {
+    client-id     = var.alertmanager_oauth_client_id
+    client-secret = var.alertmanager_oauth_client_secret
+    cookie-secret = var.alertmanager_oauth_cookie_secret
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.monitoring_namespace
+  ]
+}

--- a/monitoring/templates/alertmanager_oauth2_proxy_values.tftpl
+++ b/monitoring/templates/alertmanager_oauth2_proxy_values.tftpl
@@ -1,7 +1,5 @@
 config:
-  clientID: "${client_id}"
-  clientSecret: "${client_secret}"
-  cookieSecret: "${cookie_secret}"
+  existingSecret: ${existing_secret}
   configFile: |-
     provider = "keycloak-oidc"
     provider_display_name = "Keycloak"

--- a/monitoring/templates/prometheus_oauth2_proxy_values.tftpl
+++ b/monitoring/templates/prometheus_oauth2_proxy_values.tftpl
@@ -1,7 +1,5 @@
 config:
-  clientID: "${client_id}"
-  clientSecret: "${client_secret}"
-  cookieSecret: "${cookie_secret}"
+  existingSecret: ${existing_secret}
   configFile: |-
     provider = "keycloak-oidc"
     provider_display_name = "Keycloak"

--- a/monitoring/templates/prometheus_values.tftpl
+++ b/monitoring/templates/prometheus_values.tftpl
@@ -14,7 +14,10 @@ prometheus:
 
 grafana:
   enabled: true
-  adminPassword: "${grafana_admin_password}"
+  admin:
+    existingSecret: ${grafana_admin_existing_secret}
+    userKey: admin-user
+    passwordKey: admin-password
   assertNoLeakedSecrets: false
   persistence:
     enabled: true

--- a/notebooks/jupyterhub.tf
+++ b/notebooks/jupyterhub.tf
@@ -83,8 +83,7 @@ resource "helm_release" "jupyterhub" {
 
   values = [
     templatefile("${path.module}/templates/jupyterhub_values.tftpl", {
-      oauth_client_id               = var.jupyterhub_oauth_client_id
-      oauth_client_secret           = var.jupyterhub_oauth_client_secret
+      oauth_secret_name             = kubernetes_secret_v1.jupyterhub_oauth_secret.metadata[0].name
       jupyterhub_host               = local.jupyterhub_host
       keycloak_auth_url             = var.keycloak_auth_url
       keycloak_token_url            = var.keycloak_token_url
@@ -103,6 +102,7 @@ resource "helm_release" "jupyterhub" {
   depends_on = [
     kubernetes_namespace_v1.notebooks_namespace,
     kubernetes_config_map_v1.jupyterhub_examples,
-    kubernetes_role_binding_v1.jupyterhub
+    kubernetes_role_binding_v1.jupyterhub,
+    kubernetes_secret_v1.jupyterhub_oauth_secret
   ]
 }

--- a/notebooks/secret.tf
+++ b/notebooks/secret.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_secret_v1" "jupyterhub_oauth_secret" {
+  metadata {
+    name      = "jupyterhub-oauth-secret"
+    namespace = local.namespace
+    labels    = local.jupyterhub_labels
+  }
+
+  data = {
+    client_id     = var.jupyterhub_oauth_client_id
+    client_secret = var.jupyterhub_oauth_client_secret
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.notebooks_namespace
+  ]
+}

--- a/notebooks/templates/jupyterhub_values.tftpl
+++ b/notebooks/templates/jupyterhub_values.tftpl
@@ -5,8 +5,6 @@ hub:
     JupyterHub:
       authenticator_class: generic-oauth
     GenericOAuthenticator:
-      client_id: "${oauth_client_id}"
-      client_secret: "${oauth_client_secret}"
       oauth_callback_url: "http://${jupyterhub_host}/hub/oauth_callback"
       authorize_url: "${keycloak_auth_url}"
       token_url: "${keycloak_token_url}"
@@ -24,9 +22,24 @@ hub:
         - "profile"
         - "email"
         - "groups"
+  extraEnv:
+    - name: OAUTH_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: ${oauth_secret_name}
+          key: client_id
+    - name: OAUTH_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: ${oauth_secret_name}
+          key: client_secret
   extraConfig:
     spawner: |
       c.KubeSpawner.cmd = ['jupyterhub-singleuser']
+    oauth-secrets: |
+      import os
+      c.GenericOAuthenticator.client_id = os.environ['OAUTH_CLIENT_ID']
+      c.GenericOAuthenticator.client_secret = os.environ['OAUTH_CLIENT_SECRET']
 
 singleuser:
   image:

--- a/orchestration/config_map.tf
+++ b/orchestration/config_map.tf
@@ -10,8 +10,6 @@ resource "kubernetes_config_map_v1" "dagster_storage_config" {
     NESSIE_REF           = "main"
     S3_ENDPOINT          = local.s3_endpoint
     S3_WAREHOUSE         = local.warehouse_location
-    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
-    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
     S3_REGION            = "us-east-1"
     S3_PATH_STYLE_ACCESS = "true"
     S3_SSL_ENABLED       = "false"

--- a/orchestration/dagster.tf
+++ b/orchestration/dagster.tf
@@ -7,20 +7,19 @@ resource "helm_release" "dagster" {
 
   values = [
     templatefile("${path.module}/templates/dagster_values.tftpl", {
-      namespace                 = local.namespace
-      dagster_postgres_password = var.dagster_postgres_password
-      webserver_replica_num     = var.dagster_webserver_replica_num
-      max_concurrent_runs       = var.dagster_run_coordinator_max_concurrent_runs
-      service_account_name      = kubernetes_service_account_v1.dagster_sa.metadata[0].name
-      storage_config_map_name   = kubernetes_config_map_v1.dagster_storage_config.metadata[0].name
-      spark_config_map_name     = kubernetes_config_map_v1.dagster_spark_config.metadata[0].name
-      flink_config_map_name     = kubernetes_config_map_v1.dagster_flink_config.metadata[0].name
-      user_code_config_map_name = kubernetes_config_map_v1.dagster_user_code.metadata[0].name
-      nessie_uri                = local.nessie_catalog_uri
-      s3_endpoint               = local.s3_endpoint
-      s3_warehouse              = local.warehouse_location
-      s3_access_key             = var.storage_s3_access_key
-      s3_secret_key             = var.storage_s3_secret_key
+      namespace                  = local.namespace
+      webserver_replica_num      = var.dagster_webserver_replica_num
+      max_concurrent_runs        = var.dagster_run_coordinator_max_concurrent_runs
+      service_account_name       = kubernetes_service_account_v1.dagster_sa.metadata[0].name
+      storage_config_map_name    = kubernetes_config_map_v1.dagster_storage_config.metadata[0].name
+      s3_credentials_secret_name = kubernetes_secret_v1.dagster_s3_credentials.metadata[0].name
+      spark_config_map_name      = kubernetes_config_map_v1.dagster_spark_config.metadata[0].name
+      flink_config_map_name      = kubernetes_config_map_v1.dagster_flink_config.metadata[0].name
+      user_code_config_map_name  = kubernetes_config_map_v1.dagster_user_code.metadata[0].name
+      nessie_uri                 = local.nessie_catalog_uri
+      s3_endpoint                = local.s3_endpoint
+      s3_warehouse               = local.warehouse_location
+      postgres_existing_secret   = kubernetes_secret_v1.dagster_postgres_password.metadata[0].name
     })
   ]
 
@@ -29,6 +28,8 @@ resource "helm_release" "dagster" {
     kubernetes_service_account_v1.dagster_sa,
     kubernetes_config_map_v1.dagster_storage_config,
     kubernetes_config_map_v1.dagster_user_code,
-    kubernetes_role_binding_v1.dagster_job_runner_binding
+    kubernetes_role_binding_v1.dagster_job_runner_binding,
+    kubernetes_secret_v1.dagster_s3_credentials,
+    kubernetes_secret_v1.dagster_postgres_password
   ]
 }

--- a/orchestration/oauth2_proxy.tf
+++ b/orchestration/oauth2_proxy.tf
@@ -8,13 +8,14 @@ resource "helm_release" "dagster_oauth2_proxy" {
 
   values = [
     templatefile("${path.module}/templates/oauth2_proxy_values.tftpl", {
-      client_id         = var.dagster_oauth_client_id
-      client_secret     = var.dagster_oauth_client_secret
-      cookie_secret     = var.dagster_oauth_cookie_secret
+      existing_secret   = kubernetes_secret_v1.dagster_oauth2_proxy_secret.metadata[0].name
       oidc_issuer_url   = var.keycloak_issuer_url
       ingress_base_host = var.kubernetes_ingress_base_host
     })
   ]
 
-  depends_on = [helm_release.dagster]
+  depends_on = [
+    helm_release.dagster,
+    kubernetes_secret_v1.dagster_oauth2_proxy_secret
+  ]
 }

--- a/orchestration/secret.tf
+++ b/orchestration/secret.tf
@@ -1,0 +1,50 @@
+resource "kubernetes_secret_v1" "dagster_s3_credentials" {
+  metadata {
+    name      = "dagster-s3-credentials"
+    namespace = local.namespace
+    labels    = local.dagster_labels
+  }
+
+  data = {
+    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
+    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.orchestration_namespace
+  ]
+}
+
+resource "kubernetes_secret_v1" "dagster_postgres_password" {
+  metadata {
+    name      = "dagster-postgres-password"
+    namespace = local.namespace
+    labels    = local.dagster_labels
+  }
+
+  data = {
+    password          = var.dagster_postgres_password
+    postgres-password = var.dagster_postgres_password
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.orchestration_namespace
+  ]
+}
+
+resource "kubernetes_secret_v1" "dagster_oauth2_proxy_secret" {
+  metadata {
+    name      = "dagster-oauth2-proxy-secret"
+    namespace = local.namespace
+  }
+
+  data = {
+    client-id     = var.dagster_oauth_client_id
+    client-secret = var.dagster_oauth_client_secret
+    cookie-secret = var.dagster_oauth_cookie_secret
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.orchestration_namespace
+  ]
+}

--- a/orchestration/templates/dagster_values.tftpl
+++ b/orchestration/templates/dagster_values.tftpl
@@ -18,9 +18,15 @@ dagsterWebserver:
     - name: S3_WAREHOUSE
       value: "${s3_warehouse}"
     - name: S3_ACCESS_KEY_ID
-      value: "${s3_access_key}"
+      valueFrom:
+        secretKeyRef:
+          name: ${s3_credentials_secret_name}
+          key: S3_ACCESS_KEY_ID
     - name: S3_SECRET_ACCESS_KEY
-      value: "${s3_secret_key}"
+      valueFrom:
+        secretKeyRef:
+          name: ${s3_credentials_secret_name}
+          key: S3_SECRET_ACCESS_KEY
     - name: S3_REGION
       value: "us-east-1"
     - name: S3_PATH_STYLE_ACCESS
@@ -49,9 +55,15 @@ dagsterDaemon:
     - name: S3_WAREHOUSE
       value: "${s3_warehouse}"
     - name: S3_ACCESS_KEY_ID
-      value: "${s3_access_key}"
+      valueFrom:
+        secretKeyRef:
+          name: ${s3_credentials_secret_name}
+          key: S3_ACCESS_KEY_ID
     - name: S3_SECRET_ACCESS_KEY
-      value: "${s3_secret_key}"
+      valueFrom:
+        secretKeyRef:
+          name: ${s3_credentials_secret_name}
+          key: S3_SECRET_ACCESS_KEY
     - name: S3_REGION
       value: "us-east-1"
     - name: S3_PATH_STYLE_ACCESS
@@ -76,6 +88,8 @@ runLauncher:
         - name: ${storage_config_map_name}
         - name: ${spark_config_map_name}
         - name: ${flink_config_map_name}
+      envSecrets:
+        - name: ${s3_credentials_secret_name}
       envVars:
         - "DLT_S3_BUCKET=agartha-raw"
         - "DAGSTER_CLI_API_GRPC_LAZY_LOAD_USER_CODE=1"
@@ -110,8 +124,10 @@ runLauncher:
 postgresql:
   enabled: true
   auth:
-    password: "${dagster_postgres_password}"
-    postgresPassword: "${dagster_postgres_password}"
+    existingSecret: ${postgres_existing_secret}
+    secretKeys:
+      userPasswordKey: password
+      adminPasswordKey: postgres-password
   primary:
     persistence:
       enabled: true

--- a/orchestration/templates/oauth2_proxy_values.tftpl
+++ b/orchestration/templates/oauth2_proxy_values.tftpl
@@ -1,7 +1,5 @@
 config:
-  clientID: "${client_id}"
-  clientSecret: "${client_secret}"
-  cookieSecret: "${cookie_secret}"
+  existingSecret: ${existing_secret}
   configFile: |-
     provider = "keycloak-oidc"
     provider_display_name = "Keycloak"

--- a/processing/config_map.tf
+++ b/processing/config_map.tf
@@ -12,8 +12,6 @@ resource "kubernetes_config_map_v1" "spark_storage_config" {
     NESSIE_REF           = "main"
     S3_ENDPOINT          = "http://minio.agartha-storage.svc.cluster.local:9000"
     S3_WAREHOUSE         = "s3a://agartha-warehouse/"
-    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
-    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
     S3_REGION            = "us-east-1"
     S3_PATH_STYLE_ACCESS = "true"
     S3_SSL_ENABLED       = "false"
@@ -38,8 +36,6 @@ resource "kubernetes_config_map_v1" "flink_storage_config" {
     NESSIE_REF           = "main"
     S3_ENDPOINT          = "http://minio.agartha-storage.svc.cluster.local:9000"
     S3_WAREHOUSE         = "s3a://agartha-warehouse/"
-    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
-    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
     S3_REGION            = "us-east-1"
     S3_PATH_STYLE_ACCESS = "true"
   }
@@ -62,8 +58,6 @@ resource "kubernetes_config_map_v1" "trino_storage_config" {
     NESSIE_URI           = "http://nessie.agartha-catalog.svc.cluster.local:19120/api/v2"
     S3_ENDPOINT          = var.storage_s3_endpoint
     S3_WAREHOUSE         = var.storage_s3_warehouse_location
-    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
-    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
     S3_REGION            = "us-east-1"
     S3_PATH_STYLE_ACCESS = "true"
   }

--- a/processing/secret.tf
+++ b/processing/secret.tf
@@ -1,0 +1,75 @@
+resource "kubernetes_secret_v1" "spark_s3_credentials" {
+  metadata {
+    name      = "spark-s3-credentials"
+    namespace = local.spark_namespace
+    labels = {
+      app = "spark"
+    }
+  }
+
+  data = {
+    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
+    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.processing_namespace_spark
+  ]
+}
+
+resource "kubernetes_secret_v1" "flink_s3_credentials" {
+  metadata {
+    name      = "flink-s3-credentials"
+    namespace = local.flink_namespace
+    labels = {
+      app = "flink"
+    }
+  }
+
+  data = {
+    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
+    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.processing_namespace_flink
+  ]
+}
+
+resource "kubernetes_secret_v1" "trino_s3_credentials" {
+  metadata {
+    name      = "trino-s3-credentials"
+    namespace = local.trino_namespace
+    labels = {
+      app = "trino"
+    }
+  }
+
+  data = {
+    S3_ACCESS_KEY_ID     = var.storage_s3_access_key
+    S3_SECRET_ACCESS_KEY = var.storage_s3_secret_key
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.processing_namespace_trino
+  ]
+}
+
+resource "kubernetes_secret_v1" "trino_auth_secrets" {
+  metadata {
+    name      = "trino-auth-secrets"
+    namespace = local.trino_namespace
+    labels = {
+      app = "trino"
+    }
+  }
+
+  data = {
+    oauth-client-secret    = var.trino_oauth_client_secret
+    internal-shared-secret = var.trino_internal_shared_secret
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.processing_namespace_trino
+  ]
+}

--- a/processing/trino.tf
+++ b/processing/trino.tf
@@ -8,21 +8,24 @@ resource "helm_release" "trino" {
   timeout = 600 # 10 minutes for image pulls on slow connections
 
   # Issues with setting additionalCatalogs via 'set' so using template
+  # NOTE: S3 credentials in additionalCatalogs and auth secrets in coordinator config
+  # remain as template interpolation because Trino's catalog properties files and
+  # server config don't support secretKeyRef or environment variable substitution.
   values = [
-    "${templatefile("${path.module}/templates/trino_values.tftpl", {
-      storage_s3_warehouse_location = "${var.storage_s3_warehouse_location}"
-      storage_s3_endpoint           = "${var.storage_s3_endpoint}"
-      storage_s3_access_key         = "${var.storage_s3_access_key}"
-      storage_s3_secret_key         = "${var.storage_s3_secret_key}"
-      keycloak_issuer_url           = "${var.keycloak_issuer_url}"
-      keycloak_auth_url             = "${var.keycloak_auth_url}"
-      keycloak_token_url            = "${var.keycloak_token_url}"
-      keycloak_jwks_url             = "${var.keycloak_jwks_url}"
-      keycloak_userinfo_url         = "${var.keycloak_userinfo_url}"
-      trino_oauth_client_id         = "${var.trino_oauth_client_id}"
-      trino_oauth_client_secret     = "${var.trino_oauth_client_secret}"
-      trino_internal_shared_secret  = "${var.trino_internal_shared_secret}"
-    })}"
+    templatefile("${path.module}/templates/trino_values.tftpl", {
+      storage_s3_warehouse_location = var.storage_s3_warehouse_location
+      storage_s3_endpoint           = var.storage_s3_endpoint
+      storage_s3_access_key         = var.storage_s3_access_key
+      storage_s3_secret_key         = var.storage_s3_secret_key
+      keycloak_issuer_url           = var.keycloak_issuer_url
+      keycloak_auth_url             = var.keycloak_auth_url
+      keycloak_token_url            = var.keycloak_token_url
+      keycloak_jwks_url             = var.keycloak_jwks_url
+      keycloak_userinfo_url         = var.keycloak_userinfo_url
+      trino_oauth_client_id         = var.trino_oauth_client_id
+      trino_oauth_client_secret     = var.trino_oauth_client_secret
+      trino_internal_shared_secret  = var.trino_internal_shared_secret
+    })
   ]
 
   set = [
@@ -41,6 +44,8 @@ resource "helm_release" "trino" {
   ]
 
   depends_on = [
-    kubernetes_namespace_v1.processing_namespace_trino
+    kubernetes_namespace_v1.processing_namespace_trino,
+    kubernetes_secret_v1.trino_s3_credentials,
+    kubernetes_secret_v1.trino_auth_secrets
   ]
 }


### PR DESCRIPTION
…Secrets

Migrate sensitive values (S3 keys, passwords, OAuth secrets) out of ConfigMaps and inline Helm template interpolation into proper kubernetes_secret_v1 resources with secretKeyRef/existingSecret patterns.

- processing: Extract S3 credentials from ConfigMaps into dedicated secrets; create trino-auth-secrets for OAuth/internal shared secret
- orchestration: Move S3 credentials and Dagster PostgreSQL password to secrets; use secretKeyRef in Dagster env vars, envSecrets for run launcher, and existingSecret for PostgreSQL subchart; use existingSecret for OAuth2-Proxy
- monitoring: Create Grafana admin credentials secret with grafana.admin.existingSecret; create secrets for both OAuth2-Proxy instances using config.existingSecret
- business_intelligence: Create superset-oauth-credentials secret; inject via envFromSecrets with os.environ references in Python configOverrides
- notebooks: Create JupyterHub OAuth secret; inject via hub.extraEnv secretKeyRef with extraConfig Python to set authenticator credentials
- identity: Create keycloak-admin-password secret with auth.existingSecret; convert realm ConfigMap to Secret (contains embedded OAuth client secrets); keep inline postgresql.auth.password due to Bitnami subchart image validation incompatibility with existingSecret
- catalog: Use auth.existingSecret for Nessie PostgreSQL chart