### PR TITLE
Add configurable CPU/memory resource limits to all components

### DIFF
--- a/business_intelligence/superset.tf
+++ b/business_intelligence/superset.tf
@@ -60,6 +60,10 @@ resource "helm_release" "superset" {
       keycloak_api_base_url         = var.keycloak_api_base_url
       oauth_credentials_secret_name = kubernetes_secret_v1.superset_oauth_credentials.metadata[0].name
       superset_admin_password       = random_password.superset_admin_password.result
+      node_resources                = var.superset_node_resources
+      worker_resources              = var.superset_worker_resources
+      postgres_resources            = var.superset_postgres_resources
+      redis_resources               = var.superset_redis_resources
     })
   ]
 

--- a/business_intelligence/templates/superset_values.tftpl
+++ b/business_intelligence/templates/superset_values.tftpl
@@ -91,9 +91,23 @@ envFromSecrets:
 
 supersetNode:
   replicaCount: ${superset_node_replica_num}
+  resources:
+    requests:
+      cpu: "${node_resources.requests.cpu}"
+      memory: "${node_resources.requests.memory}"
+    limits:
+      cpu: "${node_resources.limits.cpu}"
+      memory: "${node_resources.limits.memory}"
 
 supersetWorker:
   replicaCount: ${superset_worker_replica_num}
+  resources:
+    requests:
+      cpu: "${worker_resources.requests.cpu}"
+      memory: "${worker_resources.requests.memory}"
+    limits:
+      cpu: "${worker_resources.limits.cpu}"
+      memory: "${worker_resources.limits.memory}"
 
 init:
   adminUser:
@@ -106,10 +120,24 @@ init:
 postgresql:
   image:
     tag: latest
+  resources:
+    requests:
+      cpu: "${postgres_resources.requests.cpu}"
+      memory: "${postgres_resources.requests.memory}"
+    limits:
+      cpu: "${postgres_resources.limits.cpu}"
+      memory: "${postgres_resources.limits.memory}"
 
 redis:
   image:
     tag: latest
+  resources:
+    requests:
+      cpu: "${redis_resources.requests.cpu}"
+      memory: "${redis_resources.requests.memory}"
+    limits:
+      cpu: "${redis_resources.limits.cpu}"
+      memory: "${redis_resources.limits.memory}"
 
 bootstrapScript: |
   #!/bin/bash

--- a/business_intelligence/variables.tf
+++ b/business_intelligence/variables.tf
@@ -70,3 +70,51 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to bi namespace"
 }
+
+variable "superset_node_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset webserver nodes"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "2Gi" }
+  }
+}
+
+variable "superset_worker_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset workers"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "2Gi" }
+  }
+}
+
+variable "superset_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "superset_redis_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset Redis"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}

--- a/catalog/nessie.tf
+++ b/catalog/nessie.tf
@@ -85,6 +85,22 @@ resource "helm_release" "nessie_postgres" {
     {
       name  = "volumePermissions.enabled"
       value = "true"
+    },
+    {
+      name  = "primary.resources.requests.cpu"
+      value = var.nessie_postgres_resources.requests.cpu
+    },
+    {
+      name  = "primary.resources.requests.memory"
+      value = var.nessie_postgres_resources.requests.memory
+    },
+    {
+      name  = "primary.resources.limits.cpu"
+      value = var.nessie_postgres_resources.limits.cpu
+    },
+    {
+      name  = "primary.resources.limits.memory"
+      value = var.nessie_postgres_resources.limits.memory
     }
   ]
 
@@ -165,6 +181,22 @@ resource "helm_release" "nessie" {
     {
       name  = "catalog.iceberg.warehouses[0].location"
       value = "s3://${var.storage_s3_warehouse_bucket}/"
+    },
+    {
+      name  = "resources.requests.cpu"
+      value = var.nessie_resources.requests.cpu
+    },
+    {
+      name  = "resources.requests.memory"
+      value = var.nessie_resources.requests.memory
+    },
+    {
+      name  = "resources.limits.cpu"
+      value = var.nessie_resources.limits.cpu
+    },
+    {
+      name  = "resources.limits.memory"
+      value = var.nessie_resources.limits.memory
     }
   ]
 

--- a/catalog/variables.tf
+++ b/catalog/variables.tf
@@ -50,3 +50,27 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to catalog namespace"
 }
+
+variable "nessie_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Nessie PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "nessie_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Nessie"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}

--- a/identity/keycloak.tf
+++ b/identity/keycloak.tf
@@ -161,6 +161,22 @@ resource "helm_release" "keycloak" {
       value = "12-debian-12-r50"
     },
     {
+      name  = "postgresql.primary.resources.requests.cpu"
+      value = var.keycloak_postgres_resources.requests.cpu
+    },
+    {
+      name  = "postgresql.primary.resources.requests.memory"
+      value = var.keycloak_postgres_resources.requests.memory
+    },
+    {
+      name  = "postgresql.primary.resources.limits.cpu"
+      value = var.keycloak_postgres_resources.limits.cpu
+    },
+    {
+      name  = "postgresql.primary.resources.limits.memory"
+      value = var.keycloak_postgres_resources.limits.memory
+    },
+    {
       name  = "resources.limits.cpu"
       value = "1000m"
     },

--- a/identity/variables.tf
+++ b/identity/variables.tf
@@ -96,3 +96,15 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to identity namespace"
 }
+
+variable "keycloak_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Keycloak PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,9 @@ module "agartha_storage" {
   minio_tenant_volumes_per_server_num = 4
   minio_tenant_size_per_volume_gb     = 4
 
+  minio_operator_resources = var.storage_minio_operator_resources
+  minio_tenant_resources   = var.storage_minio_tenant_resources
+
   # Keycloak OAuth integration
   minio_oauth_client_id      = module.agartha_identity.keycloak_minio_client_id
   minio_oauth_client_secret  = module.agartha_identity.keycloak_minio_client_secret
@@ -50,6 +53,9 @@ module "agartha_catalog" {
   storage_s3_warehouse_bucket = var.storage_s3_warehouse_bucket_name
   catalog_postgres_password   = var.catalog_postgres_password
 
+  nessie_postgres_resources = var.catalog_nessie_postgres_resources
+  nessie_resources          = var.catalog_nessie_resources
+
   # TLS
   tls_certificate = file(var.tls_certificate_path)
   tls_private_key = file(var.tls_private_key_path)
@@ -86,6 +92,12 @@ module "agartha_monitoring" {
   flink_namespace  = "agartha-processing-flink"
 
   loki_storage_size_gb = 10
+
+  prometheus_server_resources = var.monitoring_prometheus_server_resources
+  grafana_resources           = var.monitoring_grafana_resources
+  alertmanager_resources      = var.monitoring_alertmanager_resources
+  loki_resources              = var.monitoring_loki_resources
+  promtail_resources          = var.monitoring_promtail_resources
 
   # Keycloak OAuth integration
   grafana_oauth_client_id     = module.agartha_identity.keycloak_grafana_client_id
@@ -132,6 +144,8 @@ module "agartha_identity" {
   keycloak_postgres_storage_size_gb = 10
   keycloak_replicas                 = 1
 
+  keycloak_postgres_resources = var.identity_keycloak_postgres_resources
+
   grafana_oauth_client_secret      = var.identity_grafana_oauth_client_secret
   superset_oauth_client_secret     = var.identity_superset_oauth_client_secret
   trino_oauth_client_secret        = var.identity_trino_oauth_client_secret
@@ -173,6 +187,11 @@ module "agartha_processing" {
   storage_s3_secret_key         = var.storage_s3_secret_key
 
   trino_cluster_worker_num = 2
+
+  spark_operator_resources    = var.processing_spark_operator_resources
+  flink_operator_resources    = var.processing_flink_operator_resources
+  trino_coordinator_resources = var.processing_trino_coordinator_resources
+  trino_worker_resources      = var.processing_trino_worker_resources
 
   # Keycloak OAuth integration
   trino_oauth_client_id        = module.agartha_identity.keycloak_trino_client_id
@@ -223,6 +242,11 @@ module "business_intelligence" {
 
   superset_node_replica_num   = 1
   superset_worker_replica_num = 1
+
+  superset_node_resources     = var.bi_superset_node_resources
+  superset_worker_resources   = var.bi_superset_worker_resources
+  superset_postgres_resources = var.bi_superset_postgres_resources
+  superset_redis_resources    = var.bi_superset_redis_resources
 
   # Keycloak OAuth integration
   superset_oauth_client_id     = module.agartha_identity.keycloak_superset_client_id
@@ -305,6 +329,9 @@ module "agartha_notebooks" {
   trino_port = 8080
 
   jupyterhub_storage_size_gb = 10
+
+  jupyterhub_hub_resources   = var.notebooks_jupyterhub_hub_resources
+  jupyterhub_proxy_resources = var.notebooks_jupyterhub_proxy_resources
 
   # Keycloak OAuth
   jupyterhub_oauth_client_id     = module.agartha_identity.keycloak_jupyterhub_client_id

--- a/monitoring/loki.tf
+++ b/monitoring/loki.tf
@@ -9,6 +9,8 @@ resource "helm_release" "loki_stack" {
   values = [
     templatefile("${path.module}/templates/loki_values.tftpl", {
       loki_storage_size_gb = var.loki_storage_size_gb
+      loki_resources       = var.loki_resources
+      promtail_resources   = var.promtail_resources
     })
   ]
 

--- a/monitoring/prometheus.tf
+++ b/monitoring/prometheus.tf
@@ -5,6 +5,7 @@ resource "helm_release" "kube_prometheus_stack" {
   chart            = "kube-prometheus-stack"
   version          = "81.0.0"
   create_namespace = false
+  timeout          = 600
 
   values = [
     templatefile("${path.module}/templates/prometheus_values.tftpl", {
@@ -23,6 +24,9 @@ resource "helm_release" "kube_prometheus_stack" {
       keycloak_token_url            = var.keycloak_token_url
       keycloak_userinfo_url         = var.keycloak_userinfo_url
       ingress_base_host             = var.kubernetes_ingress_base_host
+      prometheus_server_resources   = var.prometheus_server_resources
+      grafana_resources             = var.grafana_resources
+      alertmanager_resources        = var.alertmanager_resources
     })
   ]
 

--- a/monitoring/templates/loki_values.tftpl
+++ b/monitoring/templates/loki_values.tftpl
@@ -1,5 +1,12 @@
 loki:
   enabled: true
+  resources:
+    requests:
+      cpu: "${loki_resources.requests.cpu}"
+      memory: "${loki_resources.requests.memory}"
+    limits:
+      cpu: "${loki_resources.limits.cpu}"
+      memory: "${loki_resources.limits.memory}"
   persistence:
     enabled: true
     size: ${loki_storage_size_gb}Gi
@@ -44,6 +51,13 @@ loki:
 
 promtail:
   enabled: true
+  resources:
+    requests:
+      cpu: "${promtail_resources.requests.cpu}"
+      memory: "${promtail_resources.requests.memory}"
+    limits:
+      cpu: "${promtail_resources.limits.cpu}"
+      memory: "${promtail_resources.limits.memory}"
   config:
     clients:
       - url: http://loki:3100/loki/api/v1/push

--- a/monitoring/templates/prometheus_values.tftpl
+++ b/monitoring/templates/prometheus_values.tftpl
@@ -1,6 +1,13 @@
 prometheus:
   prometheusSpec:
     retention: ${prometheus_retention_days}d
+    resources:
+      requests:
+        cpu: "${prometheus_server_resources.requests.cpu}"
+        memory: "${prometheus_server_resources.requests.memory}"
+      limits:
+        cpu: "${prometheus_server_resources.limits.cpu}"
+        memory: "${prometheus_server_resources.limits.memory}"
     storageSpec:
       volumeClaimTemplate:
         spec:
@@ -14,6 +21,15 @@ prometheus:
 
 grafana:
   enabled: true
+  initChownData:
+    enabled: false
+  resources:
+    requests:
+      cpu: "${grafana_resources.requests.cpu}"
+      memory: "${grafana_resources.requests.memory}"
+    limits:
+      cpu: "${grafana_resources.limits.cpu}"
+      memory: "${grafana_resources.limits.memory}"
   admin:
     existingSecret: ${grafana_admin_existing_secret}
     userKey: admin-user
@@ -51,6 +67,13 @@ grafana:
 alertmanager:
   enabled: true
   alertmanagerSpec:
+    resources:
+      requests:
+        cpu: "${alertmanager_resources.requests.cpu}"
+        memory: "${alertmanager_resources.requests.memory}"
+      limits:
+        cpu: "${alertmanager_resources.limits.cpu}"
+        memory: "${alertmanager_resources.limits.memory}"
     storage:
       volumeClaimTemplate:
         spec:

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -149,3 +149,63 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to monitoring namespace"
 }
+
+variable "prometheus_server_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Prometheus server"
+  default = {
+    requests = { cpu = "500m", memory = "1Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "grafana_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Grafana"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "alertmanager_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Alertmanager"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}
+
+variable "loki_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Loki"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}
+
+variable "promtail_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Promtail"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}

--- a/notebooks/jupyterhub.tf
+++ b/notebooks/jupyterhub.tf
@@ -96,6 +96,8 @@ resource "helm_release" "jupyterhub" {
       nessie_uri                    = var.nessie_uri
       trino_host                    = var.trino_host
       trino_port                    = var.trino_port
+      hub_resources                 = var.jupyterhub_hub_resources
+      proxy_resources               = var.jupyterhub_proxy_resources
     })
   ]
 

--- a/notebooks/templates/jupyterhub_values.tftpl
+++ b/notebooks/templates/jupyterhub_values.tftpl
@@ -1,6 +1,13 @@
 # JupyterHub Helm values with Keycloak SSO integration
 
 hub:
+  resources:
+    requests:
+      cpu: "${hub_resources.requests.cpu}"
+      memory: "${hub_resources.requests.memory}"
+    limits:
+      cpu: "${hub_resources.limits.cpu}"
+      memory: "${hub_resources.limits.memory}"
   config:
     JupyterHub:
       authenticator_class: generic-oauth
@@ -108,6 +115,14 @@ cull:
   maxAge: 0
 
 proxy:
+  chp:
+    resources:
+      requests:
+        cpu: "${proxy_resources.requests.cpu}"
+        memory: "${proxy_resources.requests.memory}"
+      limits:
+        cpu: "${proxy_resources.limits.cpu}"
+        memory: "${proxy_resources.limits.memory}"
   service:
     type: ClusterIP
 

--- a/notebooks/variables.tf
+++ b/notebooks/variables.tf
@@ -89,3 +89,27 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to notebooks namespace"
 }
+
+variable "jupyterhub_hub_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for JupyterHub hub"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}
+
+variable "jupyterhub_proxy_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for JupyterHub proxy"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}

--- a/processing/flink.tf
+++ b/processing/flink.tf
@@ -17,6 +17,22 @@ resource "helm_release" "flink_operator" {
     {
       name  = "webhook.create"
       value = "false"
+    },
+    {
+      name  = "resources.requests.cpu"
+      value = var.flink_operator_resources.requests.cpu
+    },
+    {
+      name  = "resources.requests.memory"
+      value = var.flink_operator_resources.requests.memory
+    },
+    {
+      name  = "resources.limits.cpu"
+      value = var.flink_operator_resources.limits.cpu
+    },
+    {
+      name  = "resources.limits.memory"
+      value = var.flink_operator_resources.limits.memory
     }
   ]
 

--- a/processing/spark.tf
+++ b/processing/spark.tf
@@ -23,6 +23,22 @@ resource "helm_release" "spark_operator" {
     {
       name  = "ingressUrlFormat"
       value = "spark.agartha.minikubehost.com/{{$appName}}"
+    },
+    {
+      name  = "controller.resources.requests.cpu"
+      value = var.spark_operator_resources.requests.cpu
+    },
+    {
+      name  = "controller.resources.requests.memory"
+      value = var.spark_operator_resources.requests.memory
+    },
+    {
+      name  = "controller.resources.limits.cpu"
+      value = var.spark_operator_resources.limits.cpu
+    },
+    {
+      name  = "controller.resources.limits.memory"
+      value = var.spark_operator_resources.limits.memory
     }
   ]
 

--- a/processing/templates/trino_values.tftpl
+++ b/processing/templates/trino_values.tftpl
@@ -16,6 +16,24 @@ additionalConfigProperties:
   - http-server.process-forwarded=true
   - internal-communication.shared-secret=${trino_internal_shared_secret}
 
+coordinator:
+  resources:
+    requests:
+      cpu: "${coordinator_resources.requests.cpu}"
+      memory: "${coordinator_resources.requests.memory}"
+    limits:
+      cpu: "${coordinator_resources.limits.cpu}"
+      memory: "${coordinator_resources.limits.memory}"
+
+worker:
+  resources:
+    requests:
+      cpu: "${worker_resources.requests.cpu}"
+      memory: "${worker_resources.requests.memory}"
+    limits:
+      cpu: "${worker_resources.limits.cpu}"
+      memory: "${worker_resources.limits.memory}"
+
 server:
   coordinatorExtraConfig: |
     http-server.authentication.type=oauth2

--- a/processing/trino.tf
+++ b/processing/trino.tf
@@ -25,6 +25,8 @@ resource "helm_release" "trino" {
       trino_oauth_client_id         = var.trino_oauth_client_id
       trino_oauth_client_secret     = var.trino_oauth_client_secret
       trino_internal_shared_secret  = var.trino_internal_shared_secret
+      coordinator_resources         = var.trino_coordinator_resources
+      worker_resources              = var.trino_worker_resources
     })
   ]
 

--- a/processing/variables.tf
+++ b/processing/variables.tf
@@ -100,3 +100,51 @@ variable "trino_allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to trino namespace"
 }
+
+variable "spark_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Spark operator controller"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "flink_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Flink operator"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "1Gi" }
+  }
+}
+
+variable "trino_coordinator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Trino coordinator"
+  default = {
+    requests = { cpu = "1000m", memory = "2Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "trino_worker_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Trino workers"
+  default = {
+    requests = { cpu = "1000m", memory = "2Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}

--- a/storage/minio.tf
+++ b/storage/minio.tf
@@ -5,6 +5,25 @@ resource "helm_release" "minio_operator" {
   chart      = "operator"
   version    = "7.1.1"
 
+  set = [
+    {
+      name  = "resources.requests.cpu"
+      value = var.minio_operator_resources.requests.cpu
+    },
+    {
+      name  = "resources.requests.memory"
+      value = var.minio_operator_resources.requests.memory
+    },
+    {
+      name  = "resources.limits.cpu"
+      value = var.minio_operator_resources.limits.cpu
+    },
+    {
+      name  = "resources.limits.memory"
+      value = var.minio_operator_resources.limits.memory
+    }
+  ]
+
   depends_on = [
     kubernetes_namespace_v1.storage_namespace
   ]
@@ -81,6 +100,25 @@ resource "helm_release" "minio_tenant" {
     {
       name  = "tenant.certificate.externalCaCertSecret[0].name"
       value = "minio-trusted-ca"
+    },
+    #
+    # Resource limits
+    #
+    {
+      name  = "tenant.pools[0].resources.requests.cpu"
+      value = var.minio_tenant_resources.requests.cpu
+    },
+    {
+      name  = "tenant.pools[0].resources.requests.memory"
+      value = var.minio_tenant_resources.requests.memory
+    },
+    {
+      name  = "tenant.pools[0].resources.limits.cpu"
+      value = var.minio_tenant_resources.limits.cpu
+    },
+    {
+      name  = "tenant.pools[0].resources.limits.memory"
+      value = var.minio_tenant_resources.limits.memory
     }
   ]
 

--- a/storage/variables.tf
+++ b/storage/variables.tf
@@ -74,3 +74,27 @@ variable "allowed_ingress_namespaces" {
   type        = list(string)
   description = "List of namespaces allowed to ingress to storage namespace"
 }
+
+variable "minio_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the MinIO operator"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "minio_tenant_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for MinIO tenant pool-0"
+  default = {
+    requests = { cpu = "500m", memory = "1Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,247 @@ variable "backup_retention_days" {
   description = "Number of days to retain Velero backups"
   default     = 7
 }
+
+# =============================================================================
+# Resource limits
+# =============================================================================
+
+variable "storage_minio_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the MinIO operator"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "storage_minio_tenant_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for MinIO tenant pool-0"
+  default = {
+    requests = { cpu = "500m", memory = "1Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "catalog_nessie_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Nessie PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "catalog_nessie_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Nessie"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}
+
+variable "processing_spark_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Spark operator controller"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "processing_flink_operator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Flink operator"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "1Gi" }
+  }
+}
+
+variable "processing_trino_coordinator_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Trino coordinator"
+  default = {
+    requests = { cpu = "1000m", memory = "2Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "processing_trino_worker_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Trino workers"
+  default = {
+    requests = { cpu = "1000m", memory = "2Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "notebooks_jupyterhub_hub_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for JupyterHub hub"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}
+
+variable "notebooks_jupyterhub_proxy_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for JupyterHub proxy"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "bi_superset_node_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset webserver nodes"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "2Gi" }
+  }
+}
+
+variable "bi_superset_worker_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset workers"
+  default = {
+    requests = { cpu = "250m", memory = "512Mi" }
+    limits   = { cpu = "1000m", memory = "2Gi" }
+  }
+}
+
+variable "bi_superset_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "bi_superset_redis_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Superset Redis"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}
+
+variable "monitoring_prometheus_server_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for the Prometheus server"
+  default = {
+    requests = { cpu = "500m", memory = "1Gi" }
+    limits   = { cpu = "2000m", memory = "4Gi" }
+  }
+}
+
+variable "monitoring_grafana_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Grafana"
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
+variable "monitoring_alertmanager_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Alertmanager"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}
+
+variable "monitoring_loki_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Loki"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+}
+
+variable "monitoring_promtail_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Promtail"
+  default = {
+    requests = { cpu = "50m", memory = "64Mi" }
+    limits   = { cpu = "200m", memory = "256Mi" }
+  }
+}
+
+variable "identity_keycloak_postgres_resources" {
+  type = object({
+    requests = object({ cpu = string, memory = string })
+    limits   = object({ cpu = string, memory = string })
+  })
+  description = "Resource requests and limits for Keycloak PostgreSQL"
+  default = {
+    requests = { cpu = "250m", memory = "256Mi" }
+    limits   = { cpu = "500m", memory = "512Mi" }
+  }
+}


### PR DESCRIPTION
Introduce resource requests and limits for every component as configurable Terraform variables (object type with defaults), passed from terraform.tfvars through root variables/main.tf into each child module. Also add timeout to kube-prometheus-stack Helm release and disable Grafana initChownData to fix PVC permission errors on upgrades.

Components covered: MinIO operator/tenant, Nessie/PostgreSQL, Spark operator, Flink operator, Trino coordinator/worker, JupyterHub hub/proxy, Superset node/worker/PostgreSQL/Redis, Prometheus server, Grafana, Alertmanager, Loki, Promtail, and Keycloak PostgreSQL.